### PR TITLE
Correctly select entity from hass states

### DIFF
--- a/media-art-background.js
+++ b/media-art-background.js
@@ -5,7 +5,7 @@ function setBackground(root, lovelace, app, originalStyle) {
     let entityValidStates = entity.valid_states || ['playing'];
     let entityImageAttribute = entity.image_attribute || 'entity_picture';
 
-    let entityInfo = hass.states[entity];
+    let entityInfo = hass.states[entityName];
 
     if (!entityInfo) {
       console.log(`Couldn't find entity ${entityName}`);


### PR DESCRIPTION
This is my config:
```media_art_background:
  entities:
    - entity: media_player.spotify
      valid_states:
        - playing
      image_attribute: entity_picture
```

before this change the plugin would log to console, that the entity could not be found.