### PR TITLE
fix background scrolling on mobile

### DIFF
--- a/media-art-background.js
+++ b/media-art-background.js
@@ -5,7 +5,7 @@ function setupStyle(lovelace, bgroundElem) {
   let filterBlur = lovelace.config.media_art_background.blur || '10px'; // default -> blur 10 pixels
 
   // apply style to background element
-  bgroundElem.style.position = "absolute"; // fill entire window
+  bgroundElem.style.position = "fixed"; // fill entire window
   bgroundElem.style.top = 0;
   bgroundElem.style.left = 0;
   bgroundElem.style.width = "100%";
@@ -19,7 +19,6 @@ function setupStyle(lovelace, bgroundElem) {
   bgroundElem.style.backgroundRepeat = 'no-repeat';
   bgroundElem.style.backgroundPosition = 'center';
   bgroundElem.style.backgroundSize = 'cover';
-  bgroundElem.style.backgroundAttachment = 'fixed';
   bgroundElem.style.filter = `blur(${filterBlur})`;
 
   bgroundElem.style.zIndex = -1; // below view elements
@@ -72,6 +71,7 @@ const lovelace = root.lovelace;
 const bgroundElem = document.createElement("div"); // create empty container for background 
 setupStyle(lovelace, bgroundElem);
 appLayout.appendChild(bgroundElem);
+appLayout.shadowRoot.querySelector("#contentContainer").style.transform = "none";
 
 setInterval(function () { setBackground(root, lovelace, bgroundElem) }, 5000);
 setBackground(root, lovelace, bgroundElem);


### PR DESCRIPTION
I noticed that the background scrolls with the page on mobile.
Expected behaviour --> don't  scroll

Then i investigated why this happens and remembered that the css property `background-attachment:fixed` isn't supported on mobile devices for performance reasons.
Also i found out that the image container is also scrolling with the page.

So i changed the position of the bgroundElem to fixed, to keep it from scrolling with the page, but it just would not keep the element where it was supposed to be.
After invesigation i found out, that the *transform* property of: **ha-app-layout > shadow-root > div#wrapper > div#contentContainer** was set to `transform: translate(0)`.

This broke the position fixed so i changed it to `transform: none`.

Now the background does no longer scroll on mobile and desktop :)